### PR TITLE
Update react-google-maps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1172,6 +1172,11 @@
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
+    "@googlemaps/js-api-loader": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.6.0.tgz",
+      "integrity": "sha512-amuilneCf7q5A/jDUE3ml83c9NjW/3DzIqiBDFIKZcraD0JSKbetkEQa5s57Z6QY7jxcequXgoL9CKJUY1xZ5A=="
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -1473,6 +1478,27 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
+    },
+    "@react-google-maps/api": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/api/-/api-1.13.0.tgz",
+      "integrity": "sha512-mKwXziG5MbOvvcWG53FyZVZ8zjAuPNYkcS/+nYX9STMFNrI96AFq5l/zUn2QifRJnPzE8iO4V1vyMM+Ie9LpGg==",
+      "requires": {
+        "@googlemaps/js-api-loader": "1.6.0",
+        "@react-google-maps/infobox": "1.12.1",
+        "@react-google-maps/marker-clusterer": "1.12.1",
+        "invariant": "2.2.4"
+      }
+    },
+    "@react-google-maps/infobox": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/infobox/-/infobox-1.12.1.tgz",
+      "integrity": "sha512-tD/xijqRtKK/LNRzuerzuyvybnRaD8SLgCA064len4/enTo1abhQN215ZYqwbTOn7RgYt9qMgNnwoX//u3xoWw=="
+    },
+    "@react-google-maps/marker-clusterer": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/marker-clusterer/-/marker-clusterer-1.12.1.tgz",
+      "integrity": "sha512-JBSO5VJuouP/boBnSdRDCWq0UKO7jr3HvZVhis3ew+VGJ/BoCPu3lpU0HDsjjulfng+xwqLfVOIzP3QnvBPdCA=="
     },
     "@sheerun/mutationobserver-shim": {
       "version": "0.3.3",
@@ -3501,11 +3527,6 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-    },
-    "can-use-dom": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/can-use-dom/-/can-use-dom-0.1.0.tgz",
-      "integrity": "sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo="
     },
     "caniuse-api": {
       "version": "3.0.0",
@@ -6462,11 +6483,6 @@
         }
       }
     },
-    "google-maps-infobox": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/google-maps-infobox/-/google-maps-infobox-2.0.0.tgz",
-      "integrity": "sha512-hTuWmWZZSOxf5D/z7l3/hTF1grgRvLG53BEKMdjiKOG+FcK/kH7vqseUeyIU9Zj2ZIqKTOaro0nknxpAuRq4Vw=="
-    },
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -8468,16 +8484,6 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
-    },
-    "marker-clusterer-plus": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/marker-clusterer-plus/-/marker-clusterer-plus-2.1.4.tgz",
-      "integrity": "sha1-+O/3TVmdqzt9Dj/tUmTqDnBPXWc="
-    },
-    "markerwithlabel": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/markerwithlabel/-/markerwithlabel-2.0.2.tgz",
-      "integrity": "sha512-C/cbm1A0h/u54gwHk5ZJNdUU3V3+1BbCpRPMsMyFA7vF4yL+aB4rWpxACz29TpQ+cTg6/iQroExh0PMSRGtQFg=="
     },
     "md5.js": {
       "version": "1.3.5",
@@ -11105,50 +11111,6 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.7.tgz",
       "integrity": "sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA=="
     },
-    "react-google-maps": {
-      "version": "9.4.5",
-      "resolved": "https://registry.npmjs.org/react-google-maps/-/react-google-maps-9.4.5.tgz",
-      "integrity": "sha512-8z5nX9DxIcBCXuEiurmRT1VXVwnzx0C6+3Es6lxB2/OyY2SLax2/LcDu6Aldxnl3HegefTL7NJzGeaKAJ61pOA==",
-      "requires": {
-        "babel-runtime": "^6.11.6",
-        "can-use-dom": "^0.1.0",
-        "google-maps-infobox": "^2.0.0",
-        "invariant": "^2.2.1",
-        "lodash": "^4.16.2",
-        "marker-clusterer-plus": "^2.1.4",
-        "markerwithlabel": "^2.0.1",
-        "prop-types": "^15.5.8",
-        "recompose": "^0.26.0",
-        "scriptjs": "^2.5.8",
-        "warning": "^3.0.0"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-        },
-        "recompose": {
-          "version": "0.26.0",
-          "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
-          "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
-          "requires": {
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "symbol-observable": "^1.0.4"
-          }
-        },
-        "warning": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-          "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
-      }
-    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -12025,11 +11987,6 @@
         "ajv": "^6.12.4",
         "ajv-keywords": "^3.5.2"
       }
-    },
-    "scriptjs": {
-      "version": "2.5.9",
-      "resolved": "https://registry.npmjs.org/scriptjs/-/scriptjs-2.5.9.tgz",
-      "integrity": "sha512-qGVDoreyYiP1pkQnbnFAUIS5AjenNwwQBdl7zeos9etl+hYKWahjRTfzAZZYBv5xNHx7vNKCmaLDQZ6Fr2AEXg=="
     },
     "select-hose": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1172,11 +1172,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
-    "@googlemaps/js-api-loader": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.6.0.tgz",
-      "integrity": "sha512-amuilneCf7q5A/jDUE3ml83c9NjW/3DzIqiBDFIKZcraD0JSKbetkEQa5s57Z6QY7jxcequXgoL9CKJUY1xZ5A=="
-    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -1382,11 +1377,6 @@
         "@types/istanbul-reports": "^1.1.1",
         "@types/yargs": "^13.0.0"
       }
-    },
-    "@mapbox/point-geometry": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
     },
     "@material-ui/core": {
       "version": "4.11.0",
@@ -6470,17 +6460,6 @@
           "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
           "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
         }
-      }
-    },
-    "google-map-react": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/google-map-react/-/google-map-react-2.1.8.tgz",
-      "integrity": "sha512-7oaCVBO/nZBMQNTeIyGSwlWud9PgY+acO6yKxBcn95dD5I6flIOwfAfsqg8Ez751UrAOEWpP1v+PPdJaQd2Xug==",
-      "requires": {
-        "@googlemaps/js-api-loader": "^1.4.0",
-        "@mapbox/point-geometry": "^0.1.0",
-        "eventemitter3": "^4.0.4",
-        "prop-types": "^15.7.2"
       }
     },
     "google-maps-infobox": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.0",
+    "@react-google-maps/api": "^1.13.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
@@ -11,7 +12,6 @@
     "prop-types": "^15.7.2",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
-    "react-google-maps": "^9.4.5",
     "react-leaflet": "^2.7.0",
     "react-leaflet-kml": "^1.0.4",
     "react-scripts": "3.4.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
-    "google-map-react": "^2.1.8",
     "leaflet": "^1.7.1",
     "prop-types": "^15.7.2",
     "react": "^16.14.0",

--- a/public/index.html
+++ b/public/index.html
@@ -30,7 +30,6 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <script src="https://maps.googleapis.com/maps/api/js?key=%REACT_APP_GOOGLE_API_KEY%&libraries=places"></script>
     <div id="root"></div>
     <!--
       This HTML file is a template.

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { compose, withProps } from 'recompose';
+// import { compose, withProps } from 'recompose';
 import {
-  withScriptjs,
-  withGoogleMap,
   GoogleMap,
+  LoadScript,
   KmlLayer,
   // Marker,
-} from 'react-google-maps';
+  // useLoadScript,
+} from '@react-google-maps/api';
 import UserLocationMarker from '../UserLocationMarker';
 
 const GOOGLE_KEY = process.env.REACT_APP_GOOGLE_API_KEY;
@@ -15,35 +15,64 @@ function generateRandom() {
   return Math.random() * 10000000000000000;
 }
 
-const Map = compose(
-  withProps({
-    googleMapURL: `"https://maps.googleapis.com/maps/api/js?key=${GOOGLE_KEY}"`,
-    loadingElement: <div style={{ height: `100%` }} />,
-    containerElement: <div style={{ height: `100vh` }} />,
-    mapElement: <div style={{ height: `100%` }} />,
-  }),
-  withScriptjs,
-  withGoogleMap,
-)(() => (
-  <GoogleMap
-    defaultOptions={{
-      streetViewControl: false,
-      mapTypeControl: false,
-    }}
-    defaultZoom={16}
-    defaultCenter={{ lat: 44.947479, lng: -93.091638 }}
-    mapTypeId="terrain"
-  >
-    <KmlLayer
-      url={`${
-        'https://www.google.com/maps/d/kml?mid=1Lzxsanw81e7VloBq1G5_1RZj9rGHrFck' +
-        '&ver='
-      }${generateRandom()}`}
-      options={{ preserveViewport: true }}
-    />
-    <UserLocationMarker />
-  </GoogleMap>
-));
+const mapContainerStyle = { height: `100vh` };
+const mapCenter = { lat: 44.947479, lng: -93.091638 };
+const mapOptions = {
+  streetViewControl: false,
+  mapTypeControl: false,
+};
+
+function Map() {
+  return (
+    <LoadScript googleMapsApiKey={GOOGLE_KEY}>
+      <GoogleMap
+        mapContainerStyle={mapContainerStyle}
+        center={mapCenter}
+        zoom={16}
+        options={mapOptions}
+      >
+        <KmlLayer
+          url={`${
+            'https://www.google.com/maps/d/kml?mid=1Lzxsanw81e7VloBq1G5_1RZj9rGHrFck' +
+            '&ver='
+          }${generateRandom()}`}
+          options={{ preserveViewport: true }}
+        />
+        <UserLocationMarker />
+      </GoogleMap>
+    </LoadScript>
+  );
+}
+
+// const Map = compose(
+//   withProps({
+//     googleMapURL: `"https://maps.googleapis.com/maps/api/js?key=${GOOGLE_KEY}"`,
+//     loadingElement: <div style={{ height: `100%` }} />,
+//     containerElement: <div style={{ height: `100vh` }} />,
+//     mapElement: <div style={{ height: `100%` }} />,
+//   }),
+//   withScriptjs,
+//   withGoogleMap,
+// )(() => (
+//   <GoogleMap
+//     defaultOptions={{
+//       streetViewControl: false,
+//       mapTypeControl: false,
+//     }}
+//     defaultZoom={16}
+//     defaultCenter={{ lat: 44.947479, lng: -93.091638 }}
+//     mapTypeId="terrain"
+//   >
+//     <KmlLayer
+//       url={`${
+//         'https://www.google.com/maps/d/kml?mid=1Lzxsanw81e7VloBq1G5_1RZj9rGHrFck' +
+//         '&ver='
+//       }${generateRandom()}`}
+//       options={{ preserveViewport: true }}
+//     />
+//     <UserLocationMarker />
+//   </GoogleMap>
+// ));
 
 export default Map;
 

--- a/src/components/UserLocationMarker.js
+++ b/src/components/UserLocationMarker.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Marker } from 'react-google-maps';
+import { Marker } from '@react-google-maps/api';
 
 // These functions are place holders, and should display meaningful information for the user
 function HandleGeolocationFailure() {


### PR DESCRIPTION
This is just to move from the unmaintained `react-google-maps` to the currently maintained version `@react-google-maps/api`. Also a note in case you get confused over and over like I did: there are several similarly named and structured packages out there, this is not `google-maps-react` _or_ `google-map-react`.