### PR TITLE
Fix mobile formatting for buttons and scroll behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11095,6 +11095,11 @@
         }
       }
     },
+    "react-div-100vh": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/react-div-100vh/-/react-div-100vh-0.5.6.tgz",
+      "integrity": "sha512-foNzJeBwiWp2Xs+pDhKyX2sP9O8UoGfYyz/D+GgZaHCKS3R+lbtJc8OdgMDr03txXgPVsxGEtmjKeDcLW30xwQ=="
+    },
     "react-dom": {
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "leaflet": "^1.7.1",
     "prop-types": "^15.7.2",
     "react": "^16.14.0",
+    "react-div-100vh": "^0.5.6",
     "react-dom": "^16.14.0",
     "react-leaflet": "^2.7.0",
     "react-leaflet-kml": "^1.0.4",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
+import Div100vh from "react-div-100vh";
 import Map from './components/Map/Map';
 import ReportBtn from './components/ReportBtn';
 
 function App() {
   return (
     <>
-      <Map />
-      <ReportBtn />
+      <Div100vh>
+        <Map />
+        <ReportBtn />
+      </Div100vh>
     </>
   );
 }

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -25,6 +25,7 @@ const mapOptions = {
   mapTypeControl: false,
   fullscreenControl: false,
   gestureHandling: 'greedy',
+  zoomControl: false,
 };
 
 function Map() {


### PR DESCRIPTION
This ended up being pretty simple, however I did make a small executive decision to just remove the "plus/minus" buttons for zooming in. I personally never end up using those, and I feel like the pinch/spread gestures on mobile just work better, however I'm sure we could get them back in and formatted correctly!